### PR TITLE
Version compatability for CentOS and Rocky

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 CyVerse Ansible k3s
 ===================
 
-This role will create a k3s standalone or cluster. 
+This role will create a k3s standalone or cluster.
 
 Requirements
 ------------
@@ -18,7 +18,7 @@ In .ini format
 ````
 [k3s_masters]
   w.x.y.z
-    
+
 [k3s_agents]
   a.b.c.d
   e.f.g.h
@@ -64,6 +64,7 @@ Variable Name | Default value if not defined | Description
 K3S_DOCKER_ENABLE | true | enables the docker engine
 K3S_TRAEFIK_ENABLE | false | disable traefik ingress
 K3S_MASTER_INSTALL | true | reinstall master node(s)
+K3S_MASTER_IP | none | sets the k3s masters ip for when ansible_default_ipv4 is getting an incorrect value
 K3S_MASTER_PORT | 6443 | master node port
 K3S_POSTGRESQL_ENABLE | false | enables the use of postgresql
 K3S_POSTGRESQL_INSTALL | false | enables installation of postgresql on the first k3s master; K3S_POSTGRESQL_ENABLE must be true
@@ -101,4 +102,4 @@ This is a sample playbook:
 
 Author Information
 ------------------
-Edwin Skidmore (edwin@cyverse.org) 
+Edwin Skidmore (edwin@cyverse.org)

--- a/tasks/k3s-install.yml
+++ b/tasks/k3s-install.yml
@@ -37,6 +37,13 @@
   set_fact:
     k3s_master_ip: "{{ hostvars[groups['k3s_masters'][0]]['ansible_default_ipv4']['address'] }}"
     k3s_master_url: "https://{{ hostvars[groups['k3s_masters'][0]]['ansible_default_ipv4']['address'] }}:{{ K3S_MASTER_PORT }}"
+  when: K3S_MASTER_IP is not defined
+
+- name: SET_FACT; set the k3s_master_ip based on given value
+  set_fact:
+    k3s_master_ip: "{{ K3S_MASTER_IP }}"
+    k3s_master_url: "https://{{ K3S_MASTER_IP }}:{{ K3S_MASTER_PORT }}"
+  when: K3S_MASTER_IP is defined
 
 - name: SHELL; grab the token from the master
   shell: cat /var/lib/rancher/k3s/server/node-token
@@ -45,12 +52,12 @@
   when: inventory_hostname in groups['k3s_masters']
 
 - name: SET_FACT; set the k3s_token fact for all nodes
-  set_fact: 
+  set_fact:
     k3s_token: "{{ k3s_master_token_file.stdout }}"
   run_once: yes
 
 - name: DEBUG; print master url and token
-  debug: 
+  debug:
     msg: "k3s master url = {{ k3s_master_url }}, token = {{ k3s_token }}"
 
 ###
@@ -61,4 +68,3 @@
   args:
     warn: false
   when: groups['k3s_agents'] is defined and inventory_hostname in groups['k3s_agents']
-

--- a/tasks/postgresql.yml
+++ b/tasks/postgresql.yml
@@ -1,8 +1,14 @@
 # Note: currently, this is in a single block for the first master. Later will modify role to support HA masters
 - block:
 
-  - include_tasks: "postgresql-install-{{ hostvars[groups['k3s_masters'][0]].ansible_distribution }}.yml"
-    when: K3S_POSTGRESQL_INSTALL is defined and K3S_POSTGRESQL_INSTALL|bool
+#  - include_tasks: "postgresql-install-{{ hostvars[groups['k3s_masters'][0]].ansible_distribution }}.yml"
+#    when: K3S_POSTGRESQL_INSTALL is defined and K3S_POSTGRESQL_INSTALL|bool
+
+  - name: PACKAGE; update cache and install postgresql server and client
+    package:
+      name: "{{ POSTGRESQL_PACKAGES }}"
+      state: present
+      update_cache: yes
 
   - name: STAT; check if a password has already been writted to /opt/k3s/postgres-{{K3S_POSTGRESQL_USER}}.pass
     stat:
@@ -10,7 +16,7 @@
     register: pass_file_check
     when: K3S_POSTGRESQL_PASS is undefined
 
-  # Note: Did this because ansible variable register will not work as expected for skipped tasks. So, collapsed in bash one-liner, rather than multiple 
+  # Note: Did this because ansible variable register will not work as expected for skipped tasks. So, collapsed in bash one-liner, rather than multiple
   # ansible shell tasks
   - name: SHELL; generate a random password for postgres if K3S_POSTGRESQL_PASS is undefined
     shell: "if [ -e /opt/k3s/postgres-{{K3S_POSTGRESQL_USER}}.pass ]; then cat /opt/k3s/postgres-{{K3S_POSTGRESQL_USER}}.pass; else date | sha1sum | base64 | tee /opt/k3s/postgres-{{K3S_POSTGRESQL_USER}}.pass; fi"

--- a/vars/CentOS.yml
+++ b/vars/CentOS.yml
@@ -1,4 +1,4 @@
 POSTGRESQL_PACKAGES:
   - postgresql
-  - postgresql-client
+  - postgresql-server
   - python3-psycopg2

--- a/vars/Rocky.yml
+++ b/vars/Rocky.yml
@@ -1,4 +1,4 @@
 POSTGRESQL_PACKAGES:
   - postgresql
-  - postgresql-client
+  - postgresql-server
   - python3-psycopg2

--- a/vars/Ubuntu.yml
+++ b/vars/Ubuntu.yml
@@ -3,8 +3,6 @@
 ansible_python_interpreter: /usr/bin/python3
 
 POSTGRESQL_PACKAGES:
-  - postgresql-11
-  - postgresql-client-11
+  - postgresql
+  - postgresql-client
   - python3-psycopg2
-
-


### PR DESCRIPTION
made version compatible for more systems, and changed from fixed postgres11 to whatever postgresql the generic install is currently. The latter change was for ease of upgrading and expanding to more OS's.